### PR TITLE
Added rate limiter middleware to `server.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
 		"axios": "^0.24.0",
 		"dotenv": "^10.0.0",
 		"express": "^4.17.1",
+		"express-rate-limit": "^5.5.0",
 		"mongodb": "^4.1.2",
 		"typescript": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",
+		"@types/express-rate-limit": "^5.1.3",
 		"@types/node": "^16.9.1",
 		"@typescript-eslint/eslint-plugin": "^4.31.1",
 		"@typescript-eslint/parser": "^4.31.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
+import rateLimit from "express-rate-limit";
 
 import { getNearbyPlaces } from "./rest/getNearbyPlaces";
 import { getPlacePhoto } from "./rest/getPlacePhoto";
@@ -15,9 +16,16 @@ import { deleteRating } from "./rest/Ratings/deleteRating";
 
 const app = express();
 const port = process.env.PORT || 3030;
+const limiter = {
+	windowMs: 15 * 60 * 1000, // 15 min in ms
+	max: 1000,
+	message:
+		"The API is rate limited to a maximum of 1000 requests per 15 minutes, please lower your request rate",
+};
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(rateLimit(limiter));
 
 dotenv.config();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/express-rate-limit@^5.1.3":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@types/express-rate-limit/-/express-rate-limit-5.1.3.tgz#79f2ca40d90455a5798da6f8e06d8a3d35f4a1d6"
+  integrity sha512-H+TYy3K53uPU2TqPGFYaiWc2xJV6+bIFkDd/Ma2/h67Pa6ARk9kWE0p/K9OH1Okm0et9Sfm66fmXoAxsH2PHXg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.24"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz#ea41f93bf7e0d59cd5a76665068ed6aab6815c07"
@@ -166,7 +173,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.17.13":
+"@types/express@*", "@types/express@^4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
   integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
@@ -1205,6 +1212,11 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+express-rate-limit@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-5.5.0.tgz#27dc48b5cc325448df47d02d5f4a2183b723781d"
+  integrity sha512-/1mrKggjXMxd1/ghPub5N3d36u5VlK8KjbQFQLxYub09BWSSgSXMQbXgFiIW0BYxjM49YCj8bkihONZR2U4+mQ==
 
 express@^4.17.1:
   version "4.17.1"


### PR DESCRIPTION
Using `express-rate-limit` to rate limit the number of reqests sent to our server. Right now, its applied to the whole server, but once we implement user authentication, we can specify which routes we want rate limited this way, and which routes we want protected by user auth, or both, or whatever. Just something for right now since the server is live!

closes https://github.com/Peer-Stevens/peer/issues/101﻿
