### PR TITLE
getNearbyPlaces endpoint only returns restaurants

### DIFF
--- a/src/rest/getNearbyPlaces.ts
+++ b/src/rest/getNearbyPlaces.ts
@@ -1,8 +1,8 @@
 import {
 	Client,
-	PlacesNearbyRanking,
 	PlacesNearbyResponse,
 	Place as GooglePlace,
+	PlaceType1,
 } from "@googlemaps/google-maps-services-js";
 import { getPlaceByID } from "../db/Place/place";
 
@@ -12,24 +12,13 @@ import { getPromoMonth } from "../db/PromoMonth/promoMonth";
 
 import type { Place as DbPlace, PlaceWithA11yAndPromo } from "../db/types";
 
+import { placesNearbyByType } from "./util";
+
 export const getNearbyPlaces = async (req: Request, res: Response): Promise<void> => {
 	const client = new Client({});
-	const placesRes = await client
-		.placesNearby({
-			params: {
-				location: {
-					latitude: Number(req.query.latitude),
-					longitude: Number(req.query.longitude),
-				},
-				rankby: PlacesNearbyRanking.distance,
-				key: process.env.PLACES_API_KEY || "",
-				type: req.query.type ? String(req.query.type) : "",
-				keyword: req.query.keyword ? String(req.query.keyword) : "",
-			},
-		})
-		.catch(e => {
-			console.log(e);
-		});
+	const placesRes = await placesNearbyByType(client, req.query, PlaceType1.restaurant).catch(e =>
+		console.log(e)
+	);
 
 	// The response is either an object or void if there is an error, but we catch it anyway, so we can cast to PlacesNearbyResponse safely
 	let placesNearby = (placesRes as PlacesNearbyResponse).data.results;

--- a/src/rest/util.ts
+++ b/src/rest/util.ts
@@ -9,6 +9,8 @@ import { User } from "../db/types";
 import { AuthenticationError } from "../errorClasses";
 import { getCollection } from "../db/mongoCollections";
 import { YesNoRating } from "types";
+import { Client, PlacesNearbyRanking, PlaceType1 } from "@googlemaps/google-maps-services-js";
+import type { ParsedQs } from "qs";
 
 // Functions
 
@@ -93,6 +95,25 @@ export const isAuthenticated = async (
 export const convertToYesNoRating = (val: string): YesNoRating => {
 	if (!["0", "1", "null"].includes(val)) return null;
 	return (Number(val) === NaN ? null : Number(val)) as YesNoRating;
+};
+
+export const placesNearbyByType = async (
+	client: Client,
+	query: ParsedQs,
+	type?: string | PlaceType1
+) => {
+	return client.placesNearby({
+		params: {
+			location: {
+				latitude: Number(query.latitude),
+				longitude: Number(query.longitude),
+			},
+			rankby: PlacesNearbyRanking.distance,
+			key: process.env.PLACES_API_KEY || "",
+			type: type || "",
+			keyword: query.keyword ? String(query.keyword) : "",
+		},
+	});
 };
 
 // Constants


### PR DESCRIPTION
Closes https://github.com/Peer-Stevens/peer/issues/269

Changes the nearbyPlaces endpoint to only return places of the type "Restaurant" to represent our shift in focus. This can be changed back by changing the argument to the new function `placesNearbyByType` back to `req.query.type`.