### PR TITLE
Re-added match to agg

### DIFF
--- a/src/db/Place/place.ts
+++ b/src/db/Place/place.ts
@@ -154,6 +154,11 @@ export async function updatePlace(id: GooglePlaceID["place_id"]): Promise<PlaceA
 
 	const pipeline = [
 		{
+			$match: {
+				placeID: id,
+			},
+		},
+		{
 			$group: {
 				_id: id,
 				guideDogAvg: {


### PR DESCRIPTION
The issue was that [this PR](https://github.com/Peer-Stevens/peer-server/pull/112/files) removed the `match` part of the aggregator pipeline, so the aggregator was actually finding and averaging ALL place ratings every time a new place was added - we didn't notice for a long time because the display of average rating was broken on the FE due to the rating fields changes, and also this explains many of them are _slightly different_ - each new place added would add one new rating and then average all of them, so the new rating would move the average slightly.